### PR TITLE
Fixing broken links on tags page

### DIFF
--- a/templates/tags.html
+++ b/templates/tags.html
@@ -10,11 +10,9 @@
       <ul class="list-inline">
         {%- for tag, articles in tags|sort %}
         <li>
-          <button type="button" class="btn btn-default">
             <a href="{{ SITEURL }}/{{ tag.url }}">
               <div class="fa fa-lg fa-tag"></div> {{ tag }} <span class="badge">{{ articles|count }}</span>
             </a>
-          </button>
         </li>
         {% endfor %}
       </ul>


### PR DESCRIPTION
`<a>` is not allowed inside `<button>`, this does not work in modern browsers and is not allowed in HTML5. See http://stackoverflow.com/questions/17253410/link-inside-a-button-not-working-in-firefox
